### PR TITLE
feat: add multi-file graft manifest support

### DIFF
--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,357 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverManifests(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create test files
+	files := []string{
+		"10-network.graft.hcl",
+		"00-base.graft.hcl",
+		"99-overrides.graft.hcl",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(tmpDir, f), []byte(""), 0644); err != nil {
+			t.Fatalf("failed to create file %s: %v", f, err)
+		}
+	}
+
+	// Create a non-graft file that should be ignored
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create main.tf: %v", err)
+	}
+
+	// Test discovery
+	manifests, err := DiscoverManifests(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverManifests failed: %v", err)
+	}
+
+	if len(manifests) != 3 {
+		t.Errorf("expected 3 manifests, got %d", len(manifests))
+	}
+
+	// Verify alphabetical order
+	expected := []string{
+		filepath.Join(tmpDir, "00-base.graft.hcl"),
+		filepath.Join(tmpDir, "10-network.graft.hcl"),
+		filepath.Join(tmpDir, "99-overrides.graft.hcl"),
+	}
+	for i, exp := range expected {
+		if manifests[i] != exp {
+			t.Errorf("expected manifests[%d] = %s, got %s", i, exp, manifests[i])
+		}
+	}
+}
+
+func TestDiscoverManifests_NoFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	manifests, err := DiscoverManifests(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverManifests failed: %v", err)
+	}
+
+	if manifests != nil {
+		t.Errorf("expected nil, got %v", manifests)
+	}
+}
+
+func TestParseMultiple_SingleFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	content := `
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+
+  override {
+    resource "aws_vpc" "this" {
+      tags = {
+        Name = "test"
+      }
+    }
+  }
+}
+`
+	filePath := filepath.Join(tmpDir, "manifest.graft.hcl")
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	m, err := ParseMultiple([]string{filePath})
+	if err != nil {
+		t.Fatalf("ParseMultiple failed: %v", err)
+	}
+
+	if len(m.Modules) != 1 {
+		t.Errorf("expected 1 module, got %d", len(m.Modules))
+	}
+
+	if m.Modules[0].Name != "vpc" {
+		t.Errorf("expected module name 'vpc', got '%s'", m.Modules[0].Name)
+	}
+}
+
+func TestParseMultiple_MergeModules(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// File A: scaffold.graft.hcl
+	contentA := `
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+
+  override {
+    resource "aws_vpc" "this" {
+      tags = {
+        Name = "vpc"
+      }
+    }
+  }
+}
+`
+	fileA := filepath.Join(tmpDir, "a_scaffold.graft.hcl")
+	if err := os.WriteFile(fileA, []byte(contentA), 0644); err != nil {
+		t.Fatalf("failed to write file A: %v", err)
+	}
+
+	// File B: fix.graft.hcl - adds a different resource to the same module
+	contentB := `
+module "vpc" {
+  override {
+    resource "aws_subnet" "private" {
+      tags = {
+        Fix = "True"
+      }
+    }
+  }
+}
+`
+	fileB := filepath.Join(tmpDir, "b_fix.graft.hcl")
+	if err := os.WriteFile(fileB, []byte(contentB), 0644); err != nil {
+		t.Fatalf("failed to write file B: %v", err)
+	}
+
+	m, err := ParseMultiple([]string{fileA, fileB})
+	if err != nil {
+		t.Fatalf("ParseMultiple failed: %v", err)
+	}
+
+	// Should have 1 merged module
+	if len(m.Modules) != 1 {
+		t.Errorf("expected 1 module, got %d", len(m.Modules))
+	}
+
+	// Module should have source and version from file A (check contains since parsing includes whitespace)
+	if !strings.Contains(m.Modules[0].Source, "terraform-aws-modules/vpc/aws") {
+		t.Errorf("expected source to contain 'terraform-aws-modules/vpc/aws', got '%s'", m.Modules[0].Source)
+	}
+
+	// Module should have 2 flattened content blocks (aws_vpc and aws_subnet resources)
+	if len(m.Modules[0].OverrideBlocks) != 2 {
+		t.Errorf("expected 2 flattened content blocks, got %d", len(m.Modules[0].OverrideBlocks))
+	}
+}
+
+func TestParseMultiple_LastWriteWins(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// File A: base version
+	contentA := `
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  version = "4.0.0"
+}
+`
+	fileA := filepath.Join(tmpDir, "a_base.graft.hcl")
+	if err := os.WriteFile(fileA, []byte(contentA), 0644); err != nil {
+		t.Fatalf("failed to write file A: %v", err)
+	}
+
+	// File B: override version (should win)
+	contentB := `
+module "vpc" {
+  version = "5.0.0"
+}
+`
+	fileB := filepath.Join(tmpDir, "b_override.graft.hcl")
+	if err := os.WriteFile(fileB, []byte(contentB), 0644); err != nil {
+		t.Fatalf("failed to write file B: %v", err)
+	}
+
+	m, err := ParseMultiple([]string{fileA, fileB})
+	if err != nil {
+		t.Fatalf("ParseMultiple failed: %v", err)
+	}
+
+	// Version should be from file B (last write wins)
+	if !strings.Contains(m.Modules[0].Version, "5.0.0") {
+		t.Errorf("expected version to contain '5.0.0', got '%s'", m.Modules[0].Version)
+	}
+
+	// Source should be preserved from file A
+	if !strings.Contains(m.Modules[0].Source, "terraform-aws-modules/vpc/aws") {
+		t.Errorf("expected source to contain 'terraform-aws-modules/vpc/aws', got '%s'", m.Modules[0].Source)
+	}
+}
+
+func TestParseMultiple_MultipleModules(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// File A: network module
+	contentA := `
+module "network" {
+  source = "terraform-aws-modules/vpc/aws"
+  
+  override {
+    resource "aws_vpc" "this" {}
+  }
+}
+`
+	fileA := filepath.Join(tmpDir, "a_network.graft.hcl")
+	if err := os.WriteFile(fileA, []byte(contentA), 0644); err != nil {
+		t.Fatalf("failed to write file A: %v", err)
+	}
+
+	// File B: security module
+	contentB := `
+module "security" {
+  source = "terraform-aws-modules/security-group/aws"
+  
+  override {
+    resource "aws_security_group" "this" {}
+  }
+}
+`
+	fileB := filepath.Join(tmpDir, "b_security.graft.hcl")
+	if err := os.WriteFile(fileB, []byte(contentB), 0644); err != nil {
+		t.Fatalf("failed to write file B: %v", err)
+	}
+
+	m, err := ParseMultiple([]string{fileA, fileB})
+	if err != nil {
+		t.Fatalf("ParseMultiple failed: %v", err)
+	}
+
+	// Should have 2 separate modules
+	if len(m.Modules) != 2 {
+		t.Errorf("expected 2 modules, got %d", len(m.Modules))
+	}
+
+	// Verify module names
+	moduleNames := make(map[string]bool)
+	for _, mod := range m.Modules {
+		moduleNames[mod.Name] = true
+	}
+
+	if !moduleNames["network"] {
+		t.Error("expected 'network' module to be present")
+	}
+	if !moduleNames["security"] {
+		t.Error("expected 'security' module to be present")
+	}
+}
+
+func TestParseMultiple_NestedModules(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "graft-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// File A: parent module with nested module
+	contentA := `
+module "parent" {
+  source = "example/parent/aws"
+  
+  module "child1" {
+    override {
+      resource "aws_instance" "this" {
+        instance_type = "t2.micro"
+      }
+    }
+  }
+}
+`
+	fileA := filepath.Join(tmpDir, "a_parent.graft.hcl")
+	if err := os.WriteFile(fileA, []byte(contentA), 0644); err != nil {
+		t.Fatalf("failed to write file A: %v", err)
+	}
+
+	// File B: adds another nested module to parent
+	contentB := `
+module "parent" {
+  module "child2" {
+    override {
+      resource "aws_instance" "this" {
+        instance_type = "t2.large"
+      }
+    }
+  }
+}
+`
+	fileB := filepath.Join(tmpDir, "b_child.graft.hcl")
+	if err := os.WriteFile(fileB, []byte(contentB), 0644); err != nil {
+		t.Fatalf("failed to write file B: %v", err)
+	}
+
+	m, err := ParseMultiple([]string{fileA, fileB})
+	if err != nil {
+		t.Fatalf("ParseMultiple failed: %v", err)
+	}
+
+	// Should have 1 parent module
+	if len(m.Modules) != 1 {
+		t.Errorf("expected 1 module, got %d", len(m.Modules))
+	}
+
+	// Parent should have 2 nested modules
+	if len(m.Modules[0].Modules) != 2 {
+		t.Errorf("expected 2 nested modules, got %d", len(m.Modules[0].Modules))
+	}
+
+	// Verify nested module names
+	nestedNames := make(map[string]bool)
+	for _, mod := range m.Modules[0].Modules {
+		nestedNames[mod.Name] = true
+	}
+
+	if !nestedNames["child1"] {
+		t.Error("expected 'child1' nested module to be present")
+	}
+	if !nestedNames["child2"] {
+		t.Error("expected 'child2' nested module to be present")
+	}
+}

--- a/internal/manifest/merge.go
+++ b/internal/manifest/merge.go
@@ -1,0 +1,169 @@
+package manifest
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// mergeModuleLists merges two lists of modules
+// Modules with the same name are deep merged
+func mergeModuleLists(base, other []Module) []Module {
+	// Build a map for quick lookup
+	moduleMap := make(map[string]Module)
+	var order []string
+
+	// Add base modules
+	for _, mod := range base {
+		moduleMap[mod.Name] = mod
+		order = append(order, mod.Name)
+	}
+
+	// Merge other modules
+	for _, mod := range other {
+		if existing, ok := moduleMap[mod.Name]; ok {
+			// Deep merge modules with the same name
+			moduleMap[mod.Name] = mergeModules(existing, mod)
+		} else {
+			moduleMap[mod.Name] = mod
+			order = append(order, mod.Name)
+		}
+	}
+
+	// Rebuild ordered list
+	var result []Module
+	for _, name := range order {
+		result = append(result, moduleMap[name])
+	}
+
+	return result
+}
+
+// mergeModules deep merges two modules with the same name
+func mergeModules(base, other Module) Module {
+	result := Module{
+		Name:           base.Name,
+		Source:         base.Source,
+		Version:        base.Version,
+		OverrideBlocks: mergeOverrideBlocks(base.OverrideBlocks, other.OverrideBlocks),
+		Modules:        mergeModuleLists(base.Modules, other.Modules),
+	}
+
+	// Last write wins for source and version if specified in other
+	if other.Source != "" {
+		result.Source = other.Source
+	}
+	if other.Version != "" {
+		result.Version = other.Version
+	}
+
+	return result
+}
+
+// mergeOverrideBlocks merges two lists of flattened content blocks (resource, data, locals, etc.)
+// Blocks with the same type and labels are deep merged using "last write wins" semantics.
+func mergeOverrideBlocks(base, other []*hclwrite.Block) []*hclwrite.Block {
+	if len(base) == 0 {
+		return other
+	}
+	if len(other) == 0 {
+		return base
+	}
+
+	// Track blocks by type and labels for merging
+	blockMap := make(map[string]*hclwrite.Block)
+	var blockOrder []string
+
+	// Process base blocks
+	for _, block := range base {
+		key := blockKey(block)
+		blockMap[key] = block
+		blockOrder = append(blockOrder, key)
+	}
+
+	// Merge other blocks
+	for _, block := range other {
+		key := blockKey(block)
+		if existing, ok := blockMap[key]; ok {
+			// Merge blocks with the same type and labels
+			blockMap[key] = mergeBlocks(existing, block)
+		} else {
+			blockMap[key] = block
+			blockOrder = append(blockOrder, key)
+		}
+	}
+
+	// Build result list preserving order
+	var result []*hclwrite.Block
+	for _, key := range blockOrder {
+		result = append(result, blockMap[key])
+	}
+
+	return result
+}
+
+// blockKey generates a unique key for a block based on type and labels
+func blockKey(block *hclwrite.Block) string {
+	return block.Type() + ":" + strings.Join(block.Labels(), ".")
+}
+
+// mergeBlocks merges two blocks with the same type and labels
+// Uses "last write wins" for attributes
+func mergeBlocks(base, other *hclwrite.Block) *hclwrite.Block {
+	result := hclwrite.NewBlock(base.Type(), base.Labels())
+
+	// Copy base attributes
+	for name, attr := range base.Body().Attributes() {
+		result.Body().SetAttributeRaw(name, attr.Expr().BuildTokens(nil))
+	}
+
+	// Merge/override with other attributes (last write wins)
+	for name, attr := range other.Body().Attributes() {
+		result.Body().SetAttributeRaw(name, attr.Expr().BuildTokens(nil))
+	}
+
+	// Merge nested blocks
+	baseBlocks := base.Body().Blocks()
+	otherBlocks := other.Body().Blocks()
+
+	nestedBlockMap := make(map[string]*hclwrite.Block)
+	var nestedBlockOrder []string
+
+	for _, b := range baseBlocks {
+		key := blockKey(b)
+		nestedBlockMap[key] = b
+		nestedBlockOrder = append(nestedBlockOrder, key)
+	}
+
+	for _, b := range otherBlocks {
+		key := blockKey(b)
+		if existing, ok := nestedBlockMap[key]; ok {
+			nestedBlockMap[key] = mergeBlocks(existing, b)
+		} else {
+			nestedBlockMap[key] = b
+			nestedBlockOrder = append(nestedBlockOrder, key)
+		}
+	}
+
+	for _, key := range nestedBlockOrder {
+		block := nestedBlockMap[key]
+		newBlock := result.Body().AppendNewBlock(block.Type(), block.Labels())
+		copyBlockContents(block, newBlock)
+	}
+
+	return result
+}
+
+// copyBlockContents copies all attributes and nested blocks from src to dst
+func copyBlockContents(src, dst *hclwrite.Block) {
+	// Copy attributes
+	for name, attr := range src.Body().Attributes() {
+		dst.Body().SetAttributeRaw(name, attr.Expr().BuildTokens(nil))
+	}
+
+	// Copy nested blocks
+	for _, block := range src.Body().Blocks() {
+		newBlock := dst.Body().AppendNewBlock(block.Type(), block.Labels())
+		copyBlockContents(block, newBlock)
+	}
+}

--- a/internal/manifest/merge_test.go
+++ b/internal/manifest/merge_test.go
@@ -1,0 +1,465 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func TestMergeModuleLists(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     []Module
+		other    []Module
+		expected []string // expected module names in order
+	}{
+		{
+			name:     "empty lists",
+			base:     nil,
+			other:    nil,
+			expected: nil,
+		},
+		{
+			name: "base only",
+			base: []Module{
+				{Name: "a"},
+				{Name: "b"},
+			},
+			other:    nil,
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "other only",
+			base: nil,
+			other: []Module{
+				{Name: "x"},
+				{Name: "y"},
+			},
+			expected: []string{"x", "y"},
+		},
+		{
+			name: "no overlap - preserves order",
+			base: []Module{
+				{Name: "a"},
+				{Name: "b"},
+			},
+			other: []Module{
+				{Name: "c"},
+				{Name: "d"},
+			},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			name: "with overlap - merges and preserves base order",
+			base: []Module{
+				{Name: "a", Source: "source-a"},
+				{Name: "b", Source: "source-b"},
+			},
+			other: []Module{
+				{Name: "b", Version: "2.0"},
+				{Name: "c", Source: "source-c"},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeModuleLists(tt.base, tt.other)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d modules, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for i, name := range tt.expected {
+				if result[i].Name != name {
+					t.Errorf("expected module[%d].Name = %q, got %q", i, name, result[i].Name)
+				}
+			}
+		})
+	}
+}
+
+func TestMergeModules(t *testing.T) {
+	tests := []struct {
+		name           string
+		base           Module
+		other          Module
+		expectedSource string
+		expectedVer    string
+	}{
+		{
+			name:           "base values preserved when other is empty",
+			base:           Module{Name: "test", Source: "base-source", Version: "1.0"},
+			other:          Module{Name: "test"},
+			expectedSource: "base-source",
+			expectedVer:    "1.0",
+		},
+		{
+			name:           "other values override base (last write wins)",
+			base:           Module{Name: "test", Source: "base-source", Version: "1.0"},
+			other:          Module{Name: "test", Source: "other-source", Version: "2.0"},
+			expectedSource: "other-source",
+			expectedVer:    "2.0",
+		},
+		{
+			name:           "partial override - only version",
+			base:           Module{Name: "test", Source: "base-source", Version: "1.0"},
+			other:          Module{Name: "test", Version: "2.0"},
+			expectedSource: "base-source",
+			expectedVer:    "2.0",
+		},
+		{
+			name:           "partial override - only source",
+			base:           Module{Name: "test", Source: "base-source", Version: "1.0"},
+			other:          Module{Name: "test", Source: "other-source"},
+			expectedSource: "other-source",
+			expectedVer:    "1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeModules(tt.base, tt.other)
+
+			if result.Source != tt.expectedSource {
+				t.Errorf("expected Source = %q, got %q", tt.expectedSource, result.Source)
+			}
+			if result.Version != tt.expectedVer {
+				t.Errorf("expected Version = %q, got %q", tt.expectedVer, result.Version)
+			}
+		})
+	}
+}
+
+func TestMergeModules_NestedModules(t *testing.T) {
+	base := Module{
+		Name: "parent",
+		Modules: []Module{
+			{Name: "child1", Source: "child1-source"},
+		},
+	}
+	other := Module{
+		Name: "parent",
+		Modules: []Module{
+			{Name: "child2", Source: "child2-source"},
+		},
+	}
+
+	result := mergeModules(base, other)
+
+	if len(result.Modules) != 2 {
+		t.Errorf("expected 2 nested modules, got %d", len(result.Modules))
+		return
+	}
+
+	names := make(map[string]bool)
+	for _, m := range result.Modules {
+		names[m.Name] = true
+	}
+
+	if !names["child1"] || !names["child2"] {
+		t.Errorf("expected both child1 and child2 in nested modules")
+	}
+}
+
+func TestMergeOverrideBlocks(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseHCL       string
+		otherHCL      string
+		expectedCount int
+		checkFunc     func(t *testing.T, result []*hclwrite.Block)
+	}{
+		{
+			name:          "empty base returns other",
+			baseHCL:       "",
+			otherHCL:      `resource "aws_vpc" "main" { cidr = "10.0.0.0/16" }`,
+			expectedCount: 1,
+		},
+		{
+			name:          "empty other returns base",
+			baseHCL:       `resource "aws_vpc" "main" { cidr = "10.0.0.0/16" }`,
+			otherHCL:      "",
+			expectedCount: 1,
+		},
+		{
+			name:          "no overlap - combines blocks",
+			baseHCL:       `resource "aws_vpc" "main" { cidr = "10.0.0.0/16" }`,
+			otherHCL:      `resource "aws_subnet" "public" { cidr = "10.0.1.0/24" }`,
+			expectedCount: 2,
+		},
+		{
+			name:          "same block - merges attributes",
+			baseHCL:       `resource "aws_vpc" "main" { cidr = "10.0.0.0/16" }`,
+			otherHCL:      `resource "aws_vpc" "main" { tags = { Name = "test" } }`,
+			expectedCount: 1,
+			checkFunc: func(t *testing.T, result []*hclwrite.Block) {
+				block := result[0]
+				attrs := block.Body().Attributes()
+				if len(attrs) != 2 {
+					t.Errorf("expected 2 attributes after merge, got %d", len(attrs))
+				}
+			},
+		},
+		{
+			name:          "same block same attr - last write wins",
+			baseHCL:       `resource "aws_vpc" "main" { cidr = "10.0.0.0/16" }`,
+			otherHCL:      `resource "aws_vpc" "main" { cidr = "192.168.0.0/16" }`,
+			expectedCount: 1,
+			checkFunc: func(t *testing.T, result []*hclwrite.Block) {
+				block := result[0]
+				attr := block.Body().GetAttribute("cidr")
+				if attr == nil {
+					t.Error("expected cidr attribute")
+					return
+				}
+				val := strings.TrimSpace(string(attr.Expr().BuildTokens(nil).Bytes()))
+				if !strings.Contains(val, "192.168.0.0/16") {
+					t.Errorf("expected cidr to be overwritten to 192.168.0.0/16, got %s", val)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base, other []*hclwrite.Block
+
+			if tt.baseHCL != "" {
+				f, diags := hclwrite.ParseConfig([]byte(tt.baseHCL), "base.hcl", hcl.Pos{Line: 1, Column: 1})
+				if diags.HasErrors() {
+					t.Fatalf("failed to parse baseHCL: %s", diags.Error())
+				}
+				base = f.Body().Blocks()
+			}
+
+			if tt.otherHCL != "" {
+				f, diags := hclwrite.ParseConfig([]byte(tt.otherHCL), "other.hcl", hcl.Pos{Line: 1, Column: 1})
+				if diags.HasErrors() {
+					t.Fatalf("failed to parse otherHCL: %s", diags.Error())
+				}
+				other = f.Body().Blocks()
+			}
+
+			result := mergeOverrideBlocks(base, other)
+
+			if len(result) != tt.expectedCount {
+				t.Errorf("expected %d blocks, got %d", tt.expectedCount, len(result))
+			}
+
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, result)
+			}
+		})
+	}
+}
+
+func TestBlockKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      string
+		labels   []string
+		expected string
+	}{
+		{
+			name:     "resource with two labels",
+			typ:      "resource",
+			labels:   []string{"aws_vpc", "main"},
+			expected: "resource:aws_vpc.main",
+		},
+		{
+			name:     "data with two labels",
+			typ:      "data",
+			labels:   []string{"aws_ami", "ubuntu"},
+			expected: "data:aws_ami.ubuntu",
+		},
+		{
+			name:     "locals with no labels",
+			typ:      "locals",
+			labels:   nil,
+			expected: "locals:",
+		},
+		{
+			name:     "variable with one label",
+			typ:      "variable",
+			labels:   []string{"instance_type"},
+			expected: "variable:instance_type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := hclwrite.NewBlock(tt.typ, tt.labels)
+			result := blockKey(block)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMergeBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseHCL  string
+		otherHCL string
+		check    func(t *testing.T, result *hclwrite.Block)
+	}{
+		{
+			name:     "merges different attributes",
+			baseHCL:  `resource "test" "example" { foo = "a" }`,
+			otherHCL: `resource "test" "example" { bar = "b" }`,
+			check: func(t *testing.T, result *hclwrite.Block) {
+				attrs := result.Body().Attributes()
+				if len(attrs) != 2 {
+					t.Errorf("expected 2 attributes, got %d", len(attrs))
+				}
+				if attrs["foo"] == nil {
+					t.Error("expected 'foo' attribute")
+				}
+				if attrs["bar"] == nil {
+					t.Error("expected 'bar' attribute")
+				}
+			},
+		},
+		{
+			name:     "last write wins for same attribute",
+			baseHCL:  `resource "test" "example" { foo = "old" }`,
+			otherHCL: `resource "test" "example" { foo = "new" }`,
+			check: func(t *testing.T, result *hclwrite.Block) {
+				attr := result.Body().GetAttribute("foo")
+				val := strings.TrimSpace(string(attr.Expr().BuildTokens(nil).Bytes()))
+				if !strings.Contains(val, "new") {
+					t.Errorf("expected foo to be 'new', got %s", val)
+				}
+			},
+		},
+		{
+			name: "merges nested blocks",
+			baseHCL: `resource "test" "example" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}`,
+			otherHCL: `resource "test" "example" {
+  timeouts {
+    create = "30m"
+  }
+}`,
+			check: func(t *testing.T, result *hclwrite.Block) {
+				blocks := result.Body().Blocks()
+				if len(blocks) != 2 {
+					t.Errorf("expected 2 nested blocks, got %d", len(blocks))
+				}
+			},
+		},
+		{
+			name: "merges same nested block",
+			baseHCL: `resource "test" "example" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}`,
+			otherHCL: `resource "test" "example" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}`,
+			check: func(t *testing.T, result *hclwrite.Block) {
+				blocks := result.Body().Blocks()
+				if len(blocks) != 1 {
+					t.Errorf("expected 1 merged lifecycle block, got %d", len(blocks))
+					return
+				}
+				lifecycleAttrs := blocks[0].Body().Attributes()
+				if len(lifecycleAttrs) != 2 {
+					t.Errorf("expected 2 attributes in lifecycle block, got %d", len(lifecycleAttrs))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fBase, _ := hclwrite.ParseConfig([]byte(tt.baseHCL), "base.hcl", hcl.Pos{Line: 1, Column: 1})
+			fOther, _ := hclwrite.ParseConfig([]byte(tt.otherHCL), "other.hcl", hcl.Pos{Line: 1, Column: 1})
+
+			base := fBase.Body().Blocks()[0]
+			other := fOther.Body().Blocks()[0]
+
+			result := mergeBlocks(base, other)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestCopyBlockContents(t *testing.T) {
+	srcHCL := `resource "test" "example" {
+  foo = "bar"
+  count = 1
+  
+  nested {
+    inner = "value"
+  }
+}`
+	f, _ := hclwrite.ParseConfig([]byte(srcHCL), "src.hcl", hcl.Pos{Line: 1, Column: 1})
+	src := f.Body().Blocks()[0]
+
+	dst := hclwrite.NewBlock("resource", []string{"test", "example"})
+	copyBlockContents(src, dst)
+
+	// Check attributes copied
+	attrs := dst.Body().Attributes()
+	if len(attrs) != 2 {
+		t.Errorf("expected 2 attributes copied, got %d", len(attrs))
+	}
+
+	// Check nested blocks copied
+	blocks := dst.Body().Blocks()
+	if len(blocks) != 1 {
+		t.Errorf("expected 1 nested block copied, got %d", len(blocks))
+	}
+
+	if blocks[0].Type() != "nested" {
+		t.Errorf("expected nested block type 'nested', got %q", blocks[0].Type())
+	}
+}
+
+func TestMergeOverrideBlocks_PreservesOrder(t *testing.T) {
+	baseHCL := `
+resource "aws_vpc" "main" {}
+resource "aws_subnet" "a" {}
+resource "aws_subnet" "b" {}
+`
+	otherHCL := `
+resource "aws_security_group" "sg" {}
+resource "aws_subnet" "a" { tags = {} }
+`
+	fBase, _ := hclwrite.ParseConfig([]byte(baseHCL), "base.hcl", hcl.Pos{Line: 1, Column: 1})
+	fOther, _ := hclwrite.ParseConfig([]byte(otherHCL), "other.hcl", hcl.Pos{Line: 1, Column: 1})
+
+	result := mergeOverrideBlocks(fBase.Body().Blocks(), fOther.Body().Blocks())
+
+	// Expected order: aws_vpc.main, aws_subnet.a, aws_subnet.b, aws_security_group.sg
+	expectedOrder := []string{
+		"resource:aws_vpc.main",
+		"resource:aws_subnet.a",
+		"resource:aws_subnet.b",
+		"resource:aws_security_group.sg",
+	}
+
+	if len(result) != len(expectedOrder) {
+		t.Fatalf("expected %d blocks, got %d", len(expectedOrder), len(result))
+	}
+
+	for i, block := range result {
+		key := blockKey(block)
+		if key != expectedOrder[i] {
+			t.Errorf("expected block[%d] = %q, got %q", i, expectedOrder[i], key)
+		}
+	}
+}

--- a/internal/patch/graft_source.go
+++ b/internal/patch/graft_source.go
@@ -6,26 +6,23 @@ import (
 )
 
 func resolveGraftTokens(overrideBlocks []*hclwrite.Block, existingBlocks map[string]*hclwrite.Block, existingLocals map[string]*hclwrite.Attribute) {
-	for _, overrideBlock := range overrideBlocks {
-		srcBody := overrideBlock.Body()
-		for _, block := range srcBody.Blocks() {
-			if block.Type() == "locals" {
-				for name, attr := range block.Body().Attributes() {
-					if targetAttr, ok := existingLocals[name]; ok {
-						valTokens := attr.Expr().BuildTokens(nil)
-						newTokens := replaceGraftSourceTokens(valTokens, targetAttr.Expr().BuildTokens(nil))
-						if newTokens != nil {
-							block.Body().SetAttributeRaw(name, newTokens)
-						}
+	for _, block := range overrideBlocks {
+		if block.Type() == "locals" {
+			for name, attr := range block.Body().Attributes() {
+				if targetAttr, ok := existingLocals[name]; ok {
+					valTokens := attr.Expr().BuildTokens(nil)
+					newTokens := replaceGraftSourceTokens(valTokens, targetAttr.Expr().BuildTokens(nil))
+					if newTokens != nil {
+						block.Body().SetAttributeRaw(name, newTokens)
 					}
 				}
-				continue
 			}
+			continue
+		}
 
-			key := blockKey(block)
-			if existingBlock := existingBlocks[key]; existingBlock != nil {
-				resolveBodyGraftSource(block.Body(), existingBlock.Body())
-			}
+		key := blockKey(block)
+		if existingBlock := existingBlocks[key]; existingBlock != nil {
+			resolveBodyGraftSource(block.Body(), existingBlock.Body())
 		}
 	}
 }

--- a/internal/patch/removal.go
+++ b/internal/patch/removal.go
@@ -14,15 +14,13 @@ import (
 
 func applyRemovals(modulePath string, overrideBlocks []*hclwrite.Block) error {
 	graftBlocks := make(map[string]*hclwrite.Block)
-	for _, overrideBlock := range overrideBlocks {
-		for _, block := range overrideBlock.Body().Blocks() {
-			graftBlock := filterBlockWithType(block, "_graft")
-			if graftBlock == nil {
-				continue
-			}
-			graftBlocks[blockKey(block)] = graftBlock
-			block.Body().RemoveBlock(graftBlock)
+	for _, block := range overrideBlocks {
+		graftBlock := filterBlockWithType(block, "_graft")
+		if graftBlock == nil {
+			continue
 		}
+		graftBlocks[blockKey(block)] = graftBlock
+		block.Body().RemoveBlock(graftBlock)
 	}
 
 	entries, err := filepath.Glob(filepath.Join(modulePath, "*.tf"))

--- a/internal/patch/removal_test.go
+++ b/internal/patch/removal_test.go
@@ -253,10 +253,11 @@ resource "foo" "bar" {
 				t.Fatalf("failed to parse override: %s", diags.Error())
 			}
 
+			// Flatten: extract content blocks from override wrappers
 			var overrides []*hclwrite.Block
 			for _, b := range f.Body().Blocks() {
 				if b.Type() == "override" {
-					overrides = append(overrides, b)
+					overrides = append(overrides, b.Body().Blocks()...)
 				}
 			}
 


### PR DESCRIPTION
- Auto-discover all *.graft.hcl files in current directory
- Deep merge manifests with alphabetical ordering (last write wins)
- Flatten override blocks after parsing for cleaner structure
- Add -m flag to specify single manifest explicitly
- Update terminology to 'graft manifest' throughout docs

New files:
- internal/manifest/merge.go: Deep merge logic for manifests
- internal/manifest/merge_test.go: Comprehensive merge tests
- internal/manifest/manifest_test.go: Discovery and parsing tests