### PR TITLE
Add acceptance tests for graft build command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.0"
+          terraform_wrapper: false
       - name: Test
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ terraform.tfstate
 
 _graft_add.tf
 _graft_override.tf
+graft

--- a/internal/acceptance/acceptance_test.go
+++ b/internal/acceptance/acceptance_test.go
@@ -1,0 +1,235 @@
+package acceptance
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/ms-henglu/graft/cmd"
+)
+
+// expectedFile defines an expected output file
+type expectedFile struct {
+	Path        string
+	Content     string   // Expected content (whitespace-normalized comparison)
+	Contains    []string // Strings that should appear (for non-exact matching)
+	NotContains []string // Strings that should NOT appear
+}
+
+// TestAcceptance runs end-to-end acceptance tests using the testdata folder.
+// Each test case directory should contain:
+// - main.tf: The Terraform configuration
+// - manifest.graft.hcl (or *.graft.hcl): The Graft manifest
+// - expected.hcl: Expected behavior specification
+//
+// The test will:
+// 1. Run terraform init to initialize the test case
+// 2. Run graft build command
+// 3. Verify expected output files are generated
+func TestAcceptance(t *testing.T) {
+	// Check if terraform is available
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform not found in PATH, skipping acceptance tests")
+	}
+
+	testdataDir := "testdata"
+
+	// Get list of test case directories
+	entries, err := os.ReadDir(testdataDir)
+	if err != nil {
+		t.Fatalf("Failed to read testdata directory: %v", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		testName := entry.Name()
+		testPath := filepath.Join(testdataDir, testName)
+
+		t.Run(testName, func(t *testing.T) {
+			runAcceptanceTest(t, testPath)
+		})
+	}
+}
+
+// runAcceptanceTest runs the graft build process for a single test case
+func runAcceptanceTest(t *testing.T, testPath string) {
+	// Store original working directory
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+
+	// Change to test case directory
+	if err := os.Chdir(testPath); err != nil {
+		t.Fatalf("Failed to change to test directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Errorf("Failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Load expected output specification
+	expectedFiles := loadExpectedHCL(t)
+
+	// Run terraform init
+	runTerraformInit(t)
+
+	// Run graft build command
+	runGraftBuild(t)
+
+	// Verify expected files
+	verifyExpectedFiles(t, expectedFiles)
+}
+
+// loadExpectedHCL loads the expected.hcl file for a test case
+func loadExpectedHCL(t *testing.T) []expectedFile {
+	t.Helper()
+
+	content, err := os.ReadFile("expected.hcl")
+	if err != nil {
+		t.Fatalf("Failed to read expected.hcl: %v", err)
+	}
+
+	f, diags := hclwrite.ParseConfig(content, "expected.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse expected.hcl: %s", diags.Error())
+	}
+
+	var files []expectedFile
+	for _, block := range f.Body().Blocks() {
+		if block.Type() != "expected" {
+			continue
+		}
+
+		if len(block.Labels()) == 0 {
+			t.Fatalf("expected block must have a path label")
+		}
+
+		ef := expectedFile{
+			Path: block.Labels()[0],
+		}
+
+		// Parse content block
+		for _, contentBlock := range block.Body().Blocks() {
+			if contentBlock.Type() == "content" {
+				// Get raw content between braces, preserving the HCL inside
+				tokens := contentBlock.Body().BuildTokens(nil)
+				ef.Content = strings.TrimSpace(string(tokens.Bytes()))
+			}
+		}
+
+		// Parse contains attribute
+		if attr := block.Body().GetAttribute("contains"); attr != nil {
+			ef.Contains = parseStringList(attr)
+		}
+
+		// Parse not_contains attribute
+		if attr := block.Body().GetAttribute("not_contains"); attr != nil {
+			ef.NotContains = parseStringList(attr)
+		}
+
+		files = append(files, ef)
+	}
+
+	return files
+}
+
+// parseStringList parses an HCL list attribute into a string slice
+func parseStringList(attr *hclwrite.Attribute) []string {
+	expr := string(attr.Expr().BuildTokens(nil).Bytes())
+	// Remove brackets and whitespace
+	expr = strings.TrimSpace(expr)
+	expr = strings.TrimPrefix(expr, "[")
+	expr = strings.TrimSuffix(expr, "]")
+	if expr == "" {
+		return nil
+	}
+	var result []string
+	for _, s := range strings.Split(expr, ",") {
+		s = strings.TrimSpace(s)
+		s = strings.Trim(s, "\"")
+		if s != "" {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// runTerraformInit runs terraform init in the current directory
+func runTerraformInit(t *testing.T) {
+	t.Helper()
+
+	cmd := exec.Command("terraform", "init", "-backend=false", "-input=false")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("terraform init failed: %v\nOutput: %s", err, string(output))
+	}
+}
+
+// runGraftBuild runs the graft build command using cmd.NewBuildCmd()
+func runGraftBuild(t *testing.T) {
+	t.Helper()
+
+	buildCmd := cmd.NewBuildCmd()
+	if err := buildCmd.Execute(); err != nil {
+		t.Fatalf("graft build failed: %v", err)
+	}
+}
+
+// verifyExpectedFiles verifies that expected files exist and contain expected content
+func verifyExpectedFiles(t *testing.T, expectedFiles []expectedFile) {
+	t.Helper()
+
+	for _, ef := range expectedFiles {
+		content, err := os.ReadFile(ef.Path)
+		if err != nil {
+			t.Errorf("Failed to read expected file %s: %v", ef.Path, err)
+			continue
+		}
+
+		contentStr := string(content)
+
+		// Check for exact content match (whitespace-normalized)
+		if ef.Content != "" {
+			if !equalIgnoringWhitespace(contentStr, ef.Content) {
+				t.Errorf("File %s content mismatch.\nExpected (normalized):\n%s\n\nActual (normalized):\n%s",
+					ef.Path, normalizeWhitespace(ef.Content), normalizeWhitespace(contentStr))
+			}
+		}
+
+		// Check for substring matches
+		for _, contains := range ef.Contains {
+			if !strings.Contains(contentStr, contains) {
+				t.Errorf("File %s does not contain expected string: %q", ef.Path, contains)
+			}
+		}
+
+		// Check for content that should not exist
+		for _, notContains := range ef.NotContains {
+			if strings.Contains(contentStr, notContains) {
+				t.Errorf("File %s contains unexpected string: %q", ef.Path, notContains)
+			}
+		}
+	}
+}
+
+// normalizeWhitespace removes extra whitespace for comparison
+func normalizeWhitespace(s string) string {
+	// Replace all whitespace sequences with a single space
+	re := regexp.MustCompile(`\s+`)
+	return strings.TrimSpace(re.ReplaceAllString(s, " "))
+}
+
+// equalIgnoringWhitespace compares two strings ignoring whitespace differences
+func equalIgnoringWhitespace(a, b string) bool {
+	return normalizeWhitespace(a) == normalizeWhitespace(b)
+}

--- a/internal/acceptance/testdata/inject-resources/expected.hcl
+++ b/internal/acceptance/testdata/inject-resources/expected.hcl
@@ -1,0 +1,18 @@
+# Tests that Graft can inject new resources and outputs into a module.
+
+expected ".graft/build/app/_graft_add.tf" {
+  content {
+    # Inject a new resource into the module
+    resource "random_id" "injected" {
+      byte_length = 4
+    }
+    # Inject a new output to expose the value
+    output "injected_id" {
+      value = random_id.injected.hex
+    }
+  }
+}
+
+expected ".terraform/modules/modules.json" {
+  contains = [".graft/build/app"]
+}

--- a/internal/acceptance/testdata/inject-resources/main.tf
+++ b/internal/acceptance/testdata/inject-resources/main.tf
@@ -1,0 +1,6 @@
+# Test Case: Inject New Resources
+# Tests that Graft can inject new resources and outputs into a module.
+
+module "app" {
+  source = "./modules/app"
+}

--- a/internal/acceptance/testdata/inject-resources/manifest.graft.hcl
+++ b/internal/acceptance/testdata/inject-resources/manifest.graft.hcl
@@ -1,0 +1,13 @@
+module "app" {
+  override {
+    # Inject a new resource into the module
+    resource "random_id" "injected" {
+      byte_length = 4
+    }
+
+    # Inject a new output to expose the value
+    output "injected_id" {
+      value = random_id.injected.hex
+    }
+  }
+}

--- a/internal/acceptance/testdata/inject-resources/modules/app/main.tf
+++ b/internal/acceptance/testdata/inject-resources/modules/app/main.tf
@@ -1,0 +1,8 @@
+resource "random_string" "name" {
+  length  = 8
+  special = false
+}
+
+output "name" {
+  value = random_string.name.result
+}

--- a/internal/acceptance/testdata/override-locals/expected.hcl
+++ b/internal/acceptance/testdata/override-locals/expected.hcl
@@ -1,0 +1,23 @@
+# Tests that Graft can override local values in a module.
+
+expected ".graft/build/app/_graft_override.tf" {
+  content {
+    locals {
+      environment = "production"
+    }
+  }
+}
+
+expected ".graft/build/app/_graft_add.tf" {
+  content {
+    locals {
+      extra_tags = {
+        ManagedBy = "Graft"
+      }
+    }
+  }
+}
+
+expected ".terraform/modules/modules.json" {
+  contains = [".graft/build/app"]
+}

--- a/internal/acceptance/testdata/override-locals/main.tf
+++ b/internal/acceptance/testdata/override-locals/main.tf
@@ -1,0 +1,6 @@
+# Test Case: Override Locals
+# Tests that Graft can override local values in a module.
+
+module "app" {
+  source = "./modules/app"
+}

--- a/internal/acceptance/testdata/override-locals/manifest.graft.hcl
+++ b/internal/acceptance/testdata/override-locals/manifest.graft.hcl
@@ -1,0 +1,10 @@
+module "app" {
+  override {
+    locals {
+      environment = "production"
+      extra_tags = {
+        ManagedBy = "Graft"
+      }
+    }
+  }
+}

--- a/internal/acceptance/testdata/override-locals/modules/app/main.tf
+++ b/internal/acceptance/testdata/override-locals/modules/app/main.tf
@@ -1,0 +1,12 @@
+locals {
+  environment = "development"
+  name        = "my-app"
+}
+
+output "environment" {
+  value = local.environment
+}
+
+output "name" {
+  value = local.name
+}

--- a/internal/acceptance/testdata/override-values/expected.hcl
+++ b/internal/acceptance/testdata/override-values/expected.hcl
@@ -1,0 +1,13 @@
+# Tests that Graft can override attribute values in a module's resources.
+
+expected ".graft/build/app/_graft_override.tf" {
+  content {
+    resource "local_file" "config" {
+      content = "overridden content"
+    }
+  }
+}
+
+expected ".terraform/modules/modules.json" {
+  contains = [".graft/build/app"]
+}

--- a/internal/acceptance/testdata/override-values/main.tf
+++ b/internal/acceptance/testdata/override-values/main.tf
@@ -1,0 +1,6 @@
+# Test Case: Override Values
+# Tests that Graft can override attribute values in a module's resources.
+
+module "app" {
+  source = "./modules/app"
+}

--- a/internal/acceptance/testdata/override-values/manifest.graft.hcl
+++ b/internal/acceptance/testdata/override-values/manifest.graft.hcl
@@ -1,0 +1,7 @@
+module "app" {
+  override {
+    resource "local_file" "config" {
+      content = "overridden content"
+    }
+  }
+}

--- a/internal/acceptance/testdata/override-values/modules/app/main.tf
+++ b/internal/acceptance/testdata/override-values/modules/app/main.tf
@@ -1,0 +1,8 @@
+resource "local_file" "config" {
+  content  = "original content"
+  filename = "${path.module}/output.txt"
+}
+
+output "file_path" {
+  value = local_file.config.filename
+}

--- a/internal/acceptance/testdata/registry-module/expected.hcl
+++ b/internal/acceptance/testdata/registry-module/expected.hcl
@@ -1,0 +1,13 @@
+# Tests that Graft can vendor and patch a module from the public Terraform registry.
+
+expected ".graft/build/labels/_graft_override.tf" {
+  content {
+    locals {
+      delimiter = "_"
+    }
+  }
+}
+
+expected ".terraform/modules/modules.json" {
+  contains = [".graft/build/labels"]
+}

--- a/internal/acceptance/testdata/registry-module/main.tf
+++ b/internal/acceptance/testdata/registry-module/main.tf
@@ -1,0 +1,20 @@
+# Test Case: Public Registry Module
+# Tests that Graft can vendor and patch a module from the public Terraform registry.
+
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+module "labels" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  namespace   = "eg"
+  environment = "dev"
+  name        = "app"
+}

--- a/internal/acceptance/testdata/registry-module/manifest.graft.hcl
+++ b/internal/acceptance/testdata/registry-module/manifest.graft.hcl
@@ -1,0 +1,8 @@
+module "labels" {
+  override {
+    # Override the delimiter used in the label
+    locals {
+      delimiter = "_"
+    }
+  }
+}

--- a/internal/acceptance/testdata/remove-attributes/expected.hcl
+++ b/internal/acceptance/testdata/remove-attributes/expected.hcl
@@ -1,0 +1,19 @@
+# Tests that Graft can remove specific attributes from resources using _graft.remove.
+
+expected ".graft/build/app/main.tf" {
+  content {
+    resource "local_file" "config" {
+      content  = "test content"
+      filename = "${path.module}/output.txt"
+    }
+
+    output "file_path" {
+      value = local_file.config.filename
+    }
+  }
+  not_contains = ["file_permission"]
+}
+
+expected ".terraform/modules/modules.json" {
+  contains = [".graft/build/app"]
+}

--- a/internal/acceptance/testdata/remove-attributes/main.tf
+++ b/internal/acceptance/testdata/remove-attributes/main.tf
@@ -1,0 +1,6 @@
+# Test Case: Remove Attributes
+# Tests that Graft can remove specific attributes from resources.
+
+module "app" {
+  source = "./modules/app"
+}

--- a/internal/acceptance/testdata/remove-attributes/manifest.graft.hcl
+++ b/internal/acceptance/testdata/remove-attributes/manifest.graft.hcl
@@ -1,0 +1,10 @@
+module "app" {
+  override {
+    resource "local_file" "config" {
+      _graft {
+        # Remove the 'file_permission' attribute
+        remove = ["file_permission"]
+      }
+    }
+  }
+}

--- a/internal/acceptance/testdata/remove-attributes/modules/app/main.tf
+++ b/internal/acceptance/testdata/remove-attributes/modules/app/main.tf
@@ -1,0 +1,9 @@
+resource "local_file" "config" {
+  content         = "test content"
+  filename        = "${path.module}/output.txt"
+  file_permission = "0644"
+}
+
+output "file_path" {
+  value = local_file.config.filename
+}

--- a/internal/acceptance/testdata/root-override/expected.hcl
+++ b/internal/acceptance/testdata/root-override/expected.hcl
@@ -1,0 +1,9 @@
+# Tests that Graft can apply overrides to root module resources.
+
+expected "_graft_override.tf" {
+  content {
+    resource "local_file" "root_config" {
+      content = "overridden root content"
+    }
+  }
+}

--- a/internal/acceptance/testdata/root-override/main.tf
+++ b/internal/acceptance/testdata/root-override/main.tf
@@ -1,0 +1,11 @@
+# Test Case: Root Override
+# Tests that Graft can apply overrides to root module resources (not in submodules).
+
+resource "local_file" "root_config" {
+  content  = "original root content"
+  filename = "${path.module}/root_output.txt"
+}
+
+output "root_file" {
+  value = local_file.root_config.filename
+}

--- a/internal/acceptance/testdata/root-override/manifest.graft.hcl
+++ b/internal/acceptance/testdata/root-override/manifest.graft.hcl
@@ -1,0 +1,6 @@
+# Override a resource in the root module
+override {
+  resource "local_file" "root_config" {
+    content = "overridden root content"
+  }
+}


### PR DESCRIPTION
Add acceptance test framework for end-to-end testing of graft build. Includes 6 test cases covering override-values, inject-resources, override-locals, remove-attributes, root-override, and registry-module scenarios.